### PR TITLE
Use CSS variables for colors

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,11 +1,20 @@
 /* Shared Stylesheet for all pages */
+:root {
+    --primary-bg: #f5f5f5;
+    --primary-text: #333;
+    --dark-bg: #2c3e50;
+    --accent: #4CAF50;
+    --light-text: #fff;
+    --footer-bg: #333;
+    --section-bg: #fff;
+}
 body {
     font-family: 'Roboto', sans-serif;
     line-height: 1.8;
     margin: 0;
     padding: 0;
-    background-color: #f5f5f5;
-    color: #333;
+    background-color: var(--primary-bg);
+    color: var(--primary-text);
 }
 
 img {
@@ -21,20 +30,20 @@ img {
 }
 
 header {
-    background-color: #2c3e50;
-    color: white;
+    background-color: var(--dark-bg);
+    color: var(--light-text);
     padding: 15px;
     text-align: center;
 }
 
 nav {
-    background-color: #4CAF50;
+    background-color: var(--accent);
     padding: 10px;
     text-align: center;
 }
 
 nav a {
-    color: white;
+    color: var(--light-text);
     padding: 10px 15px;
     text-decoration: none;
     font-weight: bold;
@@ -49,7 +58,7 @@ nav a {
 
 
 nav a:hover {
-    background-color: #333;
+    background-color: var(--footer-bg);
 }
 
 .container {
@@ -59,7 +68,7 @@ nav a:hover {
 }
 
 h1, h2, h3 {
-    color: #2c3e50;
+    color: var(--dark-bg);
 }
 
 p {
@@ -67,8 +76,8 @@ p {
 }
 
 footer {
-    background-color: #333;
-    color: white;
+    background-color: var(--footer-bg);
+    color: var(--light-text);
     padding: 10px 0;
     text-align: center;
     margin-top: 50px;
@@ -76,7 +85,7 @@ footer {
 
 /* Section styling */
 .resume-section, .portfolio-section {
-    background-color: white;
+    background-color: var(--section-bg);
     padding: 20px;
     margin-bottom: 20px;
     border-radius: 5px;
@@ -104,7 +113,7 @@ footer {
     display: flex;
     justify-content: center;
     align-items: center;
-    background-color: white; /* White background */
+    background-color: var(--section-bg); /* White background */
     padding: 20px; /* Add spacing inside the box */
     margin: 20px auto; /* Center with margin auto */
     max-width: 600px; /* Limit the width of the container */


### PR DESCRIPTION
## Summary
- centralize color definitions with CSS variables
- swap hard-coded colors for variable references

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f8941835c8330888f407d49a688ce