### PR TITLE
Remove Market Dashboard references

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -26,7 +26,6 @@
         <a href="portfolio.html">Portfolio</a>
         <a href="blog.html">Blog</a>
         <a href="contact.html">Contact</a>
-        <a href="market_dashboard.html">Esh's Market Dashboard</a>
     </nav>
 
     <div class="container">

--- a/contact.html
+++ b/contact.html
@@ -20,7 +20,6 @@
         <a href="portfolio.html">Portfolio</a>
         <a href="blog.html">Blog</a>
         <a href="contact.html">Contact</a>
-        <a href="market_dashboard.html">Esh's Market Dashboard</a>
 
     </nav>
 

--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@
         <a href="portfolio.html">Portfolio</a>
         <a href="blog.html">Blog</a>
         <a href="contact.html">Contact</a>
-        <a href="market_dashboard.html">Esh's Market Dashboard</a>
     </nav>
 
     <div class="container">
@@ -40,14 +39,6 @@
         <p>As I move forward, my goal is to leverage my skills in data science and analytics to create meaningful impact, helping businesses navigate complex challenges with precision and insight. Thanks for stopping by, and feel free to explore my projects, interests, and more!</p>
     </div>
 
-    <!-- New Button for Market Dashboard -->
-    <div class="container">
-        <h2>Esh's Market Dashboard and Tracker</h2>
-        <p>Stay up to date with the latest market trends and financial data with my custom-built dashboard.</p>
-        <p>
-            <a href="market_dashboard.html" class="btn" style="background-color: #4CAF50; color: white; padding: 10px 20px; text-align: center; text-decoration: none; display: inline-block; border-radius: 4px;">Visit Market Dashboard</a>
-        </p>
-    </div>
     
     <div class="container">
         <h2>Featured Projects</h2>

--- a/market_dashboard.html
+++ b/market_dashboard.html
@@ -21,7 +21,6 @@
         <a href="portfolio.html">Portfolio</a>
         <a href="blog.html">Blog</a>
         <a href="contact.html">Contact</a>
-        <a href="market_dashboard.html">Esh's Market Dashboard</a>
     </nav>
 
     <div class="container">

--- a/portfolio.html
+++ b/portfolio.html
@@ -20,7 +20,6 @@
         <a href="portfolio.html">Portfolio</a>
         <a href="blog.html">Blog</a>
         <a href="contact.html">Contact</a>
-        <a href="market_dashboard.html">Esh's Market Dashboard</a>
     </nav>
 
     <a href="index.html">

--- a/resume.html
+++ b/resume.html
@@ -21,7 +21,6 @@
         <a href="portfolio.html">Portfolio</a>
         <a href="blog.html">Blog</a>
         <a href="contact.html">Contact</a>
-        <a href="market_dashboard.html">Esh's Market Dashboard</a>
 
     </nav>
 


### PR DESCRIPTION
## Summary
- remove navigation link to Market Dashboard from site header
- delete Market Dashboard section from the home page

## Testing
- `grep -n "Market Dashboard" -R *.html`

------
https://chatgpt.com/codex/tasks/task_e_6840f7bdfab48330b7a3017c446c7a6a