### PR TITLE
Ensure header titles are visible

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -71,6 +71,10 @@ h1, h2, h3 {
     color: var(--dark-bg);
 }
 
+header h1 {
+    color: var(--light-text);
+}
+
 p {
     margin: 0 0 15px;
 }


### PR DESCRIPTION
## Summary
- Override global heading styling so header titles render in white for proper contrast.

## Testing
- `python -m pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_6897fcd966ec8330b91300c9604ec8e2