### PR TITLE
Add Connect 4 project section with landing, methodology, and playable opponents

### DIFF
--- a/connect4/assets/connect4.css
+++ b/connect4/assets/connect4.css
@@ -1,0 +1,147 @@
+.construction-banner {
+  background: color-mix(in srgb, var(--accent) 18%, var(--surface));
+  border-bottom: 1px solid var(--border);
+  padding: var(--space-2) 0;
+  font-size: 0.95rem;
+}
+
+.construction-banner strong {
+  color: var(--accent);
+  letter-spacing: 0.02em;
+}
+
+.connect4-nav {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.connect4-nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-3) 0;
+}
+
+.connect4-nav-links .button {
+  font-size: 0.9rem;
+  padding: 10px 18px;
+}
+
+.connect4-hero-placeholder {
+  border: 2px dashed color-mix(in srgb, var(--accent) 40%, var(--border));
+  border-radius: var(--radius-lg);
+  padding: clamp(40px, 10vw, 80px);
+  text-align: center;
+  color: var(--muted);
+  background: color-mix(in srgb, var(--surface) 92%, var(--accent) 8%);
+}
+
+.connect4-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-6);
+  align-items: start;
+}
+
+.connect4-panel h2,
+.connect4-board-section h2 {
+  margin-top: 0;
+}
+
+.connect4-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: var(--space-4) 0;
+}
+
+.connect4-status {
+  margin-top: var(--space-3);
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--text);
+  font-weight: 600;
+}
+
+.connect4-board {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--accent) 6%, var(--surface));
+  border: 1px solid var(--border);
+  max-width: min(92vw, 560px);
+  margin: 0 auto;
+}
+
+.connect4-board.is-disabled {
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.connect4-cell {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  background: var(--bg);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.connect4-cell:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.connect4-cell:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.12);
+}
+
+.connect4-cell.is-red {
+  background: #ef4444;
+}
+
+.connect4-cell.is-blue {
+  background: #2563eb;
+}
+
+.connect4-stats {
+  margin-top: var(--space-5);
+}
+
+.connect4-stats ul {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-2) 0 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.connect4-stats li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--surface) 92%, var(--accent) 8%);
+}
+
+.connect4-stats small {
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .connect4-nav-links {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .connect4-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/connect4/assets/connect4.js
+++ b/connect4/assets/connect4.js
@@ -1,0 +1,354 @@
+const CONNECT4_ROWS = 6;
+const CONNECT4_COLS = 7;
+const AI_MOVE_DELAY_MS = 300;
+
+const boardElement = document.getElementById('connect4-board');
+
+const getStatsDefaults = () => ({
+  user: 0,
+  ai: 0,
+  draws: 0,
+});
+
+const loadStats = (key) => {
+  const stored = localStorage.getItem(key);
+  if (!stored) return getStatsDefaults();
+  try {
+    const parsed = JSON.parse(stored);
+    return {
+      ...getStatsDefaults(),
+      ...parsed,
+    };
+  } catch (error) {
+    return getStatsDefaults();
+  }
+};
+
+const saveStats = (key, stats) => {
+  localStorage.setItem(key, JSON.stringify(stats));
+};
+
+const getAIMove = (boardState, opponentType) => {
+  const legalColumns = [];
+  for (let col = 0; col < CONNECT4_COLS; col += 1) {
+    if (boardState[0][col] === null) {
+      legalColumns.push(col);
+    }
+  }
+
+  if (!legalColumns.length) {
+    return null;
+  }
+
+  const randomIndex = Math.floor(Math.random() * legalColumns.length);
+  return legalColumns[randomIndex];
+};
+
+window.getAIMove = getAIMove;
+
+const initConnect4 = () => {
+  if (!boardElement) return;
+
+  const opponentType = document.body.dataset.opponent || 'cnn';
+  const statsKey = `connect4:stats:${opponentType}`;
+  const totalStatsKey = 'connect4:stats:total';
+
+  const statusElement = document.getElementById('connect4-status');
+  const startButton = document.getElementById('connect4-start');
+  const resetButton = document.getElementById('connect4-reset');
+  const resignButton = document.getElementById('connect4-resign');
+  const userColorElement = document.getElementById('connect4-user-color');
+  const aiColorElement = document.getElementById('connect4-ai-color');
+  const userWinsElement = document.getElementById('connect4-user-wins');
+  const aiWinsElement = document.getElementById('connect4-ai-wins');
+  const drawsElement = document.getElementById('connect4-draws');
+  const totalUserWinsElement = document.getElementById('connect4-total-user-wins');
+  const totalAiWinsElement = document.getElementById('connect4-total-ai-wins');
+  const totalDrawsElement = document.getElementById('connect4-total-draws');
+
+  let board = [];
+  let cells = [];
+  let currentPlayer = 'user';
+  let gameActive = false;
+  let userGoesFirst = true;
+
+  const updateStatus = (message) => {
+    if (statusElement) {
+      statusElement.textContent = message;
+    }
+  };
+
+  const updateStatsDisplay = () => {
+    const stats = loadStats(statsKey);
+    const totalStats = loadStats(totalStatsKey);
+
+    if (userWinsElement) userWinsElement.textContent = stats.user;
+    if (aiWinsElement) aiWinsElement.textContent = stats.ai;
+    if (drawsElement) drawsElement.textContent = stats.draws;
+
+    if (totalUserWinsElement) totalUserWinsElement.textContent = totalStats.user;
+    if (totalAiWinsElement) totalAiWinsElement.textContent = totalStats.ai;
+    if (totalDrawsElement) totalDrawsElement.textContent = totalStats.draws;
+  };
+
+  const recordResult = (result) => {
+    const stats = loadStats(statsKey);
+    const totalStats = loadStats(totalStatsKey);
+
+    if (result === 'user') {
+      stats.user += 1;
+      totalStats.user += 1;
+    } else if (result === 'ai') {
+      stats.ai += 1;
+      totalStats.ai += 1;
+    } else if (result === 'draw') {
+      stats.draws += 1;
+      totalStats.draws += 1;
+    }
+
+    saveStats(statsKey, stats);
+    saveStats(totalStatsKey, totalStats);
+    updateStatsDisplay();
+  };
+
+  const setColors = () => {
+    if (!userColorElement || !aiColorElement) return;
+
+    if (userGoesFirst) {
+      userColorElement.textContent = 'Red';
+      aiColorElement.textContent = 'Blue';
+    } else {
+      userColorElement.textContent = 'Blue';
+      aiColorElement.textContent = 'Red';
+    }
+  };
+
+  const createBoard = () => {
+    boardElement.innerHTML = '';
+    cells = [];
+
+    for (let row = 0; row < CONNECT4_ROWS; row += 1) {
+      const rowCells = [];
+      for (let col = 0; col < CONNECT4_COLS; col += 1) {
+        const cell = document.createElement('button');
+        cell.type = 'button';
+        cell.className = 'connect4-cell';
+        cell.dataset.row = row;
+        cell.dataset.col = col;
+        cell.setAttribute('aria-label', `Column ${col + 1}`);
+        boardElement.appendChild(cell);
+        rowCells.push(cell);
+      }
+      cells.push(rowCells);
+    }
+  };
+
+  const resetBoard = () => {
+    board = Array.from({ length: CONNECT4_ROWS }, () =>
+      Array.from({ length: CONNECT4_COLS }, () => null)
+    );
+
+    for (let row = 0; row < CONNECT4_ROWS; row += 1) {
+      for (let col = 0; col < CONNECT4_COLS; col += 1) {
+        const cell = cells[row][col];
+        cell.classList.remove('is-red', 'is-blue');
+      }
+    }
+  };
+
+  const applyPieceToCell = (row, col, player) => {
+    const cell = cells[row][col];
+    if (!cell) return;
+
+    if (player === 'user') {
+      cell.classList.add(userGoesFirst ? 'is-red' : 'is-blue');
+    } else {
+      cell.classList.add(userGoesFirst ? 'is-blue' : 'is-red');
+    }
+  };
+
+  const dropPiece = (col, player) => {
+    for (let row = CONNECT4_ROWS - 1; row >= 0; row -= 1) {
+      if (board[row][col] === null) {
+        board[row][col] = player;
+        applyPieceToCell(row, col, player);
+        return row;
+      }
+    }
+    return -1;
+  };
+
+  const checkLine = (row, col, deltaRow, deltaCol, player) => {
+    let count = 0;
+    let currentRow = row;
+    let currentCol = col;
+
+    while (
+      currentRow >= 0 &&
+      currentRow < CONNECT4_ROWS &&
+      currentCol >= 0 &&
+      currentCol < CONNECT4_COLS &&
+      board[currentRow][currentCol] === player
+    ) {
+      count += 1;
+      currentRow += deltaRow;
+      currentCol += deltaCol;
+    }
+
+    return count;
+  };
+
+  const isWinningMove = (player) => {
+    for (let row = 0; row < CONNECT4_ROWS; row += 1) {
+      for (let col = 0; col < CONNECT4_COLS; col += 1) {
+        if (board[row][col] !== player) continue;
+
+        const horizontal =
+          checkLine(row, col, 0, 1, player) + checkLine(row, col, 0, -1, player) - 1;
+        const vertical =
+          checkLine(row, col, 1, 0, player) + checkLine(row, col, -1, 0, player) - 1;
+        const diagonalDown =
+          checkLine(row, col, 1, 1, player) + checkLine(row, col, -1, -1, player) - 1;
+        const diagonalUp =
+          checkLine(row, col, -1, 1, player) + checkLine(row, col, 1, -1, player) - 1;
+
+        if (
+          horizontal >= 4 ||
+          vertical >= 4 ||
+          diagonalDown >= 4 ||
+          diagonalUp >= 4
+        ) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  };
+
+  const isBoardFull = () => board[0].every((cell) => cell !== null);
+
+  const endGame = (result, message) => {
+    gameActive = false;
+    boardElement.classList.add('is-disabled');
+
+    if (result === 'user') {
+      updateStatus(message || 'You win! Great game.');
+    } else if (result === 'ai') {
+      updateStatus(message || 'AI wins. Try again!');
+    } else {
+      updateStatus(message || 'It\'s a draw.');
+    }
+
+    recordResult(result);
+  };
+
+  const handleAIMove = () => {
+    if (!gameActive) return;
+
+    const aiMove = getAIMove(board, opponentType);
+    const fallbackMove = board[0].findIndex((cell) => cell === null);
+    const chosenMove = aiMove ?? fallbackMove;
+
+    if (chosenMove === -1 || chosenMove === null || chosenMove === undefined) {
+      endGame('draw', 'No moves left.');
+      return;
+    }
+
+    dropPiece(chosenMove, 'ai');
+
+    if (isWinningMove('ai')) {
+      endGame('ai');
+      return;
+    }
+
+    if (isBoardFull()) {
+      endGame('draw');
+      return;
+    }
+
+    currentPlayer = 'user';
+    updateStatus('Your turn.');
+  };
+
+  const requestAIMove = () => {
+    updateStatus('AI is thinking...');
+    setTimeout(handleAIMove, AI_MOVE_DELAY_MS);
+  };
+
+  const handleUserMove = (col) => {
+    if (!gameActive || currentPlayer !== 'user') return;
+
+    const row = dropPiece(col, 'user');
+    if (row === -1) return;
+
+    if (isWinningMove('user')) {
+      endGame('user');
+      return;
+    }
+
+    if (isBoardFull()) {
+      endGame('draw');
+      return;
+    }
+
+    currentPlayer = 'ai';
+    requestAIMove();
+  };
+
+  const startGame = () => {
+    const selection = document.querySelector('input[name="first-move"]:checked');
+    userGoesFirst = selection ? selection.value === 'user' : true;
+
+    resetBoard();
+    setColors();
+    gameActive = true;
+    boardElement.classList.remove('is-disabled');
+    currentPlayer = userGoesFirst ? 'user' : 'ai';
+
+    updateStatus(userGoesFirst ? 'Your turn. Drop a red piece.' : 'AI is going first...');
+
+    if (!userGoesFirst) {
+      requestAIMove();
+    }
+  };
+
+  const resetGame = () => {
+    gameActive = false;
+    currentPlayer = 'user';
+    resetBoard();
+    boardElement.classList.add('is-disabled');
+    updateStatus('Choose who goes first, then start the game.');
+  };
+
+  boardElement.addEventListener('click', (event) => {
+    const cell = event.target.closest('button[data-col]');
+    if (!cell) return;
+    const col = Number(cell.dataset.col);
+    if (Number.isNaN(col)) return;
+    handleUserMove(col);
+  });
+
+  if (startButton) {
+    startButton.addEventListener('click', startGame);
+  }
+
+  if (resetButton) {
+    resetButton.addEventListener('click', resetGame);
+  }
+
+  if (resignButton) {
+    resignButton.addEventListener('click', () => {
+      if (!gameActive) return;
+      endGame('ai', 'You resigned. AI takes the win.');
+    });
+  }
+
+  createBoard();
+  resetBoard();
+  setColors();
+  updateStatsDisplay();
+  resetGame();
+};
+
+initConnect4();

--- a/connect4/index.html
+++ b/connect4/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Connect 4 Project | Eshaan Arora</title>
+  <meta name="description" content="Connect 4 research project landing page featuring gameplay demos and training methodology.">
+  <meta property="og:title" content="Connect 4 Project | Eshaan Arora">
+  <meta property="og:description" content="Explore the Connect 4 research project, gameplay demos, and model training notes.">
+  <meta property="og:image" content="/images/headshot.jpeg">
+  <meta property="og:type" content="website">
+  <meta name="color-scheme" content="light dark">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="/connect4/assets/connect4.css">
+  <script src="/js/main.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <div class="construction-banner">
+    <div class="container">
+      <strong>UNDER CONSTRUCTION</strong> This Connect 4 project space is actively being built—check back soon for full write-ups and updates.
+    </div>
+  </div>
+
+  <nav class="connect4-nav" aria-label="Connect 4 quick links">
+    <div class="container connect4-nav-links">
+      <a class="button button-secondary" href="/">Back to Site</a>
+      <a class="button button-secondary" href="/connect4/">Back to Connect 4 Landing Page</a>
+      <a class="button button-secondary" href="/connect4/training-methodology/">Training Methodology</a>
+      <a class="button button-secondary" href="/connect4/play-cnn/">Play our Convoluted Neural Network Opponent</a>
+      <a class="button button-secondary" href="/connect4/play-transformer/">Play our Transformer Opponent</a>
+    </div>
+  </nav>
+
+  <header class="site-header">
+    <div class="container nav-bar">
+      <a class="logo" href="/index.html">Eshaan Arora</a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="/index.html#about">About</a>
+        <a href="/index.html#experience">Experience</a>
+        <a href="/index.html#projects">Projects</a>
+        <a href="/index.html#skills">Skills</a>
+        <a href="/contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <a class="button button-secondary" href="/resume.html">Resume</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false" aria-label="Toggle dark mode">
+          <span aria-hidden="true">◐</span>
+          <span data-theme-label>Light</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="hero">
+      <div class="container hero-grid">
+        <div data-reveal class="reveal">
+          <p class="section-subtitle">Connect 4 · Applied machine learning · Interactive demos</p>
+          <h1>Connect 4: research experiments and playable AI opponents.</h1>
+          <p>
+            This space will showcase how we trained multiple models to master Connect 4, alongside
+            playable demos and methodology notes. Use the buttons above to explore the experiments.
+          </p>
+        </div>
+        <div class="hero-card" data-reveal>
+          <div class="connect4-hero-placeholder" aria-label="Connect 4 hero image placeholder">
+            Image placeholder for Connect 4 project artwork
+          </div>
+          <p>
+            We will replace this placeholder with the project hero image once final assets are ready.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="section-header" data-reveal>
+          <h2 class="section-title">What you can explore</h2>
+          <p class="section-subtitle">Hands-on games, model notes, and a preview of future benchmarks.</p>
+        </div>
+        <div class="grid-2">
+          <article class="card reveal" data-reveal>
+            <h3>Play the AI opponents</h3>
+            <p>
+              Jump into a match against the Convoluted Neural Network or Transformer opponent and see
+              how each model behaves in real time.
+            </p>
+            <div class="project-links">
+              <a href="/connect4/play-cnn/">Play the CNN opponent</a>
+              <a href="/connect4/play-transformer/">Play the Transformer opponent</a>
+            </div>
+          </article>
+          <article class="card reveal" data-reveal>
+            <h3>Training methodology</h3>
+            <p>
+              Dive into the data pipeline, training objectives, and evaluation approach that power each
+              model. Full write-ups are coming soon.
+            </p>
+            <div class="project-links">
+              <a href="/connect4/training-methodology/">View methodology notes</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>&copy; 2024 Eshaan Arora · <a href="/index.html">Home</a> · <a href="/blog.html">Blog</a></p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/connect4/play-cnn/index.html
+++ b/connect4/play-cnn/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Play Connect 4 vs CNN | Eshaan Arora</title>
+  <meta name="description" content="Play Connect 4 against the Convoluted Neural Network opponent.">
+  <meta property="og:title" content="Play Connect 4 vs CNN | Eshaan Arora">
+  <meta property="og:description" content="Interactive Connect 4 game with a Convoluted Neural Network opponent.">
+  <meta property="og:image" content="/images/headshot.jpeg">
+  <meta property="og:type" content="website">
+  <meta name="color-scheme" content="light dark">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="/connect4/assets/connect4.css">
+  <script src="/js/main.js" defer></script>
+  <script src="/connect4/assets/connect4.js" defer></script>
+</head>
+<body data-opponent="cnn">
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <div class="construction-banner">
+    <div class="container">
+      <strong>UNDER CONSTRUCTION</strong> The CNN opponent is live, but analytics and tuning are still in progress.
+    </div>
+  </div>
+
+  <nav class="connect4-nav" aria-label="Connect 4 quick links">
+    <div class="container connect4-nav-links">
+      <a class="button button-secondary" href="/">Back to Site</a>
+      <a class="button button-secondary" href="/connect4/">Back to Connect 4 Landing Page</a>
+      <a class="button button-secondary" href="/connect4/training-methodology/">Training Methodology</a>
+      <a class="button button-secondary" href="/connect4/play-cnn/">Play our Convoluted Neural Network Opponent</a>
+      <a class="button button-secondary" href="/connect4/play-transformer/">Play our Transformer Opponent</a>
+    </div>
+  </nav>
+
+  <header class="site-header">
+    <div class="container nav-bar">
+      <a class="logo" href="/index.html">Eshaan Arora</a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="/index.html#about">About</a>
+        <a href="/index.html#experience">Experience</a>
+        <a href="/index.html#projects">Projects</a>
+        <a href="/index.html#skills">Skills</a>
+        <a href="/contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <a class="button button-secondary" href="/resume.html">Resume</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false" aria-label="Toggle dark mode">
+          <span aria-hidden="true">◐</span>
+          <span data-theme-label>Light</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="section">
+    <div class="container">
+      <div class="section-header" data-reveal>
+        <h1 class="section-title">Play the Convoluted Neural Network Opponent</h1>
+        <p class="section-subtitle">Challenge our CNN-based model and track your match record.</p>
+      </div>
+
+      <div class="connect4-layout">
+        <section class="card connect4-panel" aria-label="Game controls">
+          <h2>Game setup</h2>
+          <p>Choose whether you go first or second before starting the game.</p>
+
+          <div class="connect4-choice">
+            <label>
+              <input type="radio" name="first-move" value="user" checked>
+              I go first (Red)
+            </label>
+            <br>
+            <label>
+              <input type="radio" name="first-move" value="ai">
+              AI goes first (Red)
+            </label>
+          </div>
+
+          <div class="connect4-actions">
+            <button class="button button-primary" id="connect4-start" type="button">Start Game</button>
+            <button class="button button-secondary" id="connect4-reset" type="button">Reset</button>
+            <button class="button button-secondary" id="connect4-resign" type="button">Resign</button>
+          </div>
+
+          <div class="connect4-status" id="connect4-status" aria-live="polite">
+            Choose who goes first, then start the game.
+          </div>
+
+          <div class="connect4-colors">
+            <p><strong>Your color:</strong> <span id="connect4-user-color">Red</span></p>
+            <p><strong>AI color:</strong> <span id="connect4-ai-color">Blue</span></p>
+          </div>
+
+          <div class="connect4-stats">
+            <h3>Match record (CNN opponent)</h3>
+            <ul>
+              <li>User wins <span id="connect4-user-wins">0</span></li>
+              <li>AI wins <span id="connect4-ai-wins">0</span></li>
+              <li>Draws <span id="connect4-draws">0</span></li>
+            </ul>
+            <small>Combined totals across all opponents:</small>
+            <ul>
+              <li>User wins <span id="connect4-total-user-wins">0</span></li>
+              <li>AI wins <span id="connect4-total-ai-wins">0</span></li>
+              <li>Draws <span id="connect4-total-draws">0</span></li>
+            </ul>
+          </div>
+        </section>
+
+        <section class="card connect4-board-section" aria-label="Connect 4 board">
+          <h2>Board</h2>
+          <div class="connect4-board" id="connect4-board" role="grid" aria-label="Connect 4 board"></div>
+          <p class="section-subtitle" style="margin-top: var(--space-4);">
+            Tip: Click any column to drop your piece. The AI will respond automatically.
+          </p>
+        </section>
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>&copy; 2024 Eshaan Arora · <a href="/index.html">Home</a> · <a href="/blog.html">Blog</a></p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/connect4/play-transformer/index.html
+++ b/connect4/play-transformer/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Play Connect 4 vs Transformer | Eshaan Arora</title>
+  <meta name="description" content="Play Connect 4 against the Transformer-based opponent.">
+  <meta property="og:title" content="Play Connect 4 vs Transformer | Eshaan Arora">
+  <meta property="og:description" content="Interactive Connect 4 game with a Transformer opponent.">
+  <meta property="og:image" content="/images/headshot.jpeg">
+  <meta property="og:type" content="website">
+  <meta name="color-scheme" content="light dark">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="/connect4/assets/connect4.css">
+  <script src="/js/main.js" defer></script>
+  <script src="/connect4/assets/connect4.js" defer></script>
+</head>
+<body data-opponent="transformer">
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <div class="construction-banner">
+    <div class="container">
+      <strong>UNDER CONSTRUCTION</strong> The Transformer opponent is playable, but improvements are still underway.
+    </div>
+  </div>
+
+  <nav class="connect4-nav" aria-label="Connect 4 quick links">
+    <div class="container connect4-nav-links">
+      <a class="button button-secondary" href="/">Back to Site</a>
+      <a class="button button-secondary" href="/connect4/">Back to Connect 4 Landing Page</a>
+      <a class="button button-secondary" href="/connect4/training-methodology/">Training Methodology</a>
+      <a class="button button-secondary" href="/connect4/play-cnn/">Play our Convoluted Neural Network Opponent</a>
+      <a class="button button-secondary" href="/connect4/play-transformer/">Play our Transformer Opponent</a>
+    </div>
+  </nav>
+
+  <header class="site-header">
+    <div class="container nav-bar">
+      <a class="logo" href="/index.html">Eshaan Arora</a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="/index.html#about">About</a>
+        <a href="/index.html#experience">Experience</a>
+        <a href="/index.html#projects">Projects</a>
+        <a href="/index.html#skills">Skills</a>
+        <a href="/contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <a class="button button-secondary" href="/resume.html">Resume</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false" aria-label="Toggle dark mode">
+          <span aria-hidden="true">◐</span>
+          <span data-theme-label>Light</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="section">
+    <div class="container">
+      <div class="section-header" data-reveal>
+        <h1 class="section-title">Play the Transformer Opponent</h1>
+        <p class="section-subtitle">Test the Transformer model and keep track of your results.</p>
+      </div>
+
+      <div class="connect4-layout">
+        <section class="card connect4-panel" aria-label="Game controls">
+          <h2>Game setup</h2>
+          <p>Choose whether you go first or second before starting the game.</p>
+
+          <div class="connect4-choice">
+            <label>
+              <input type="radio" name="first-move" value="user" checked>
+              I go first (Red)
+            </label>
+            <br>
+            <label>
+              <input type="radio" name="first-move" value="ai">
+              AI goes first (Red)
+            </label>
+          </div>
+
+          <div class="connect4-actions">
+            <button class="button button-primary" id="connect4-start" type="button">Start Game</button>
+            <button class="button button-secondary" id="connect4-reset" type="button">Reset</button>
+            <button class="button button-secondary" id="connect4-resign" type="button">Resign</button>
+          </div>
+
+          <div class="connect4-status" id="connect4-status" aria-live="polite">
+            Choose who goes first, then start the game.
+          </div>
+
+          <div class="connect4-colors">
+            <p><strong>Your color:</strong> <span id="connect4-user-color">Red</span></p>
+            <p><strong>AI color:</strong> <span id="connect4-ai-color">Blue</span></p>
+          </div>
+
+          <div class="connect4-stats">
+            <h3>Match record (Transformer opponent)</h3>
+            <ul>
+              <li>User wins <span id="connect4-user-wins">0</span></li>
+              <li>AI wins <span id="connect4-ai-wins">0</span></li>
+              <li>Draws <span id="connect4-draws">0</span></li>
+            </ul>
+            <small>Combined totals across all opponents:</small>
+            <ul>
+              <li>User wins <span id="connect4-total-user-wins">0</span></li>
+              <li>AI wins <span id="connect4-total-ai-wins">0</span></li>
+              <li>Draws <span id="connect4-total-draws">0</span></li>
+            </ul>
+          </div>
+        </section>
+
+        <section class="card connect4-board-section" aria-label="Connect 4 board">
+          <h2>Board</h2>
+          <div class="connect4-board" id="connect4-board" role="grid" aria-label="Connect 4 board"></div>
+          <p class="section-subtitle" style="margin-top: var(--space-4);">
+            Tip: Click any column to drop your piece. The AI will respond automatically.
+          </p>
+        </section>
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>&copy; 2024 Eshaan Arora · <a href="/index.html">Home</a> · <a href="/blog.html">Blog</a></p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/connect4/training-methodology/index.html
+++ b/connect4/training-methodology/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Connect 4 Training Methodology | Eshaan Arora</title>
+  <meta name="description" content="Training methodology notes for the Connect 4 AI opponents.">
+  <meta property="og:title" content="Connect 4 Training Methodology | Eshaan Arora">
+  <meta property="og:description" content="Notes on training data, model architecture, and evaluation for Connect 4 AI.">
+  <meta property="og:image" content="/images/headshot.jpeg">
+  <meta property="og:type" content="website">
+  <meta name="color-scheme" content="light dark">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="/connect4/assets/connect4.css">
+  <script src="/js/main.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <div class="construction-banner">
+    <div class="container">
+      <strong>UNDER CONSTRUCTION</strong> This page is being drafted. The full methodology write-up will arrive soon.
+    </div>
+  </div>
+
+  <nav class="connect4-nav" aria-label="Connect 4 quick links">
+    <div class="container connect4-nav-links">
+      <a class="button button-secondary" href="/">Back to Site</a>
+      <a class="button button-secondary" href="/connect4/">Back to Connect 4 Landing Page</a>
+      <a class="button button-secondary" href="/connect4/training-methodology/">Training Methodology</a>
+      <a class="button button-secondary" href="/connect4/play-cnn/">Play our Convoluted Neural Network Opponent</a>
+      <a class="button button-secondary" href="/connect4/play-transformer/">Play our Transformer Opponent</a>
+    </div>
+  </nav>
+
+  <header class="site-header">
+    <div class="container nav-bar">
+      <a class="logo" href="/index.html">Eshaan Arora</a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="/index.html#about">About</a>
+        <a href="/index.html#experience">Experience</a>
+        <a href="/index.html#projects">Projects</a>
+        <a href="/index.html#skills">Skills</a>
+        <a href="/contact.html">Contact</a>
+      </nav>
+      <div class="header-actions">
+        <a class="button button-secondary" href="/resume.html">Resume</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false" aria-label="Toggle dark mode">
+          <span aria-hidden="true">◐</span>
+          <span data-theme-label>Light</span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="main" class="section">
+    <div class="container">
+      <div class="section-header" data-reveal>
+        <h1 class="section-title">Training Methodology</h1>
+        <p class="section-subtitle">A structured overview of how the Connect 4 models are trained and evaluated.</p>
+      </div>
+
+      <div class="grid-2">
+        <article class="card reveal" data-reveal>
+          <h2>Data &amp; simulation pipeline</h2>
+          <p>
+            Placeholder for the data generation strategy, self-play setup, and the feature engineering
+            used to represent Connect 4 game states.
+          </p>
+        </article>
+        <article class="card reveal" data-reveal>
+          <h2>Model architecture</h2>
+          <p>
+            Placeholder for details on the CNN and Transformer architectures, training objectives, and
+            regularization techniques.
+          </p>
+        </article>
+        <article class="card reveal" data-reveal>
+          <h2>Evaluation &amp; benchmarks</h2>
+          <p>
+            Placeholder for evaluation metrics, match simulations, and how we compare the models against
+            baseline strategies.
+          </p>
+        </article>
+        <article class="card reveal" data-reveal>
+          <h2>Future work</h2>
+          <p>
+            Placeholder for next steps, including server-based inference, skill ratings, and tournament
+            testing.
+          </p>
+        </article>
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>&copy; 2024 Eshaan Arora · <a href="/index.html">Home</a> · <a href="/blog.html">Blog</a></p>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a self-contained Connect 4 project area to the site that reuses the existing theme and components so the new pages match the current look and feel. 
- Provide interactive, client-side playable demos (two opponent flavors) and a training-methodology placeholder to showcase experiments and future server-based AI integration. 
- Keep the implementation static (plain HTML/CSS/JS) and structure the game logic so server AI can be swapped in later via a single function.

### Description
- Added a new `connect4/` section with landing, methodology, and two gameplay routes and a shared assets folder: `connect4/index.html`, `connect4/training-methodology/index.html`, `connect4/play-cnn/index.html`, `connect4/play-transformer/index.html`, `connect4/assets/connect4.css`, and `connect4/assets/connect4.js`.
- Preserved site theme by reusing the global stylesheet `css/styles.css`, the existing header/nav markup, and the site button classes; added a minimal `connect4/assets/connect4.css` only for layout and small UI bits to remain consistent.
- Implemented the client-side Connect 4 engine in `connect4/assets/connect4.js` with board UI, win/draw detection, pre-game choice (user first/second), `Start`, `Reset`, and `Resign` controls, and per-opponent and combined stats persisted to `localStorage` (namespaced keys like `connect4:stats:cnn`).
- Provided a single AI entry point `getAIMove(boardState, opponentType)` (exposed as `window.getAIMove`) that currently returns a legal random move as a stub and is trivially replaceable with a `fetch()` call to a server endpoint later.
- Each new page includes a prominent `UNDER CONSTRUCTION` banner above the header and a shared row of five navigation buttons (Back to Site, Back to Connect 4 Landing Page, Training Methodology, Play CNN, Play Transformer) as required.

### Testing
- Performed a quick smoke render by serving the static site with `python -m http.server 8000` and used a Playwright script to navigate to `/connect4/play-cnn/` and capture a full-page screenshot, which completed successfully (artifact saved as `artifacts/connect4-play-cnn.png`).
- Verified the new pages load their styles and scripts and the gameplay page initializes the board and UI controls in the browser snapshot (no blocking failures observed during the navigation/screenshot run).
- No automated unit tests were added for the game logic; no other automated test suites were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698401325a588330843c26287f49a0b2)