### PR TITLE
Prevent Square APM card button overlap with project text

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -440,3 +440,51 @@ button:focus-visible {
     transition-duration: 0.001ms !important;
   }
 }
+
+.apm-hub-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-6);
+  align-items: stretch;
+}
+
+.apm-project-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.apm-project-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+}
+
+.apm-project-content h2,
+.apm-project-content p,
+.apm-project-content .tag-list {
+  margin: 0;
+}
+
+.apm-project-card .button {
+  margin-top: var(--space-5);
+  align-self: flex-start;
+}
+
+.apm-bottom-actions {
+  margin-top: var(--space-7);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+@media (max-width: 720px) {
+  .apm-hub-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .apm-priority {
+    order: -1;
+  }
+}

--- a/square-apm-portfolio/index.html
+++ b/square-apm-portfolio/index.html
@@ -4,8 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Eshaan Arora | Square APM Portfolio</title>
-  <meta name="description" content="AI-Native Product Portfolio featuring enterprise risk analytics and consumer AI systems.">
+  <meta name="description" content="Square Associate Product Manager Program application hub featuring project deep dives.">
   <link rel="stylesheet" href="../css/styles.css">
+  <script src="../js/main.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -24,61 +25,50 @@
   <main id="main" class="section">
     <div class="container">
       <div class="section-header" data-reveal>
-        <h1 class="section-title">AI-Native Product Builder</h1>
+        <h1 class="section-title">Square APM Application Hub</h1>
         <p class="section-subtitle">
-          Building tools that move at the speed of AI to empower users—from enterprise risk leadership 
-          to consumer-facing interactive systems.
+          Welcome to my application portfolio for the Square Associate Product Manager Program. These two projects reflect how I approach product work across very different contexts: building reliable, AI-assisted decision tools for financial workflows and creating intuitive, high-performance consumer experiences.
         </p>
       </div>
 
-      <div class="grid-2-col">
-        <section class="card reveal" data-reveal>
-          <div class="card-image-placeholder">
-             
+      <section class="apm-hub-grid">
+        <article class="card reveal apm-project-card apm-priority" data-reveal>
+          <div class="apm-project-content">
+            <h2>Financial Risk Insight Engine</h2>
+            <p class="text-small">MSBA Capstone · AI for Financial Operations</p>
+            <p>
+              A decision-support system that turns complex risk data into actionable insights for analysts. The product focus was reducing time-to-clarity for high-stakes reviews through conversational querying, explainable outputs, and a workflow that supports faster escalation and better confidence.
+            </p>
+            <div class="tag-list">
+              <span class="tag">Risk Intelligence</span>
+              <span class="tag">AI Product Design</span>
+              <span class="tag">Decision Support</span>
+            </div>
           </div>
-          <h2>Building an AI-Powered Risk Analysis Tool</h2>
-          <p class="text-small">SS&C Algorithmics · B2B Strategy</p>
-          <p>
-            A conversational engine designed to solve "data paralysis" in financial risk management. 
-            By engineering a RAG pipeline with reranking and chat memory, we transformed manual queries into human-readable insights [cite: 3, 144-160].
-          </p>
-          <div class="tag-list">
-            <span class="tag">RAG Pipeline</span>
-            <span class="tag">FinTech</span>
-            <span class="tag">LLM Reliability</span>
-          </div>
-          <a class="button button-primary" href="ssc-risk-insight.html">View PM Deep Dive</a>
-        </section>
+          <a class="button button-primary" href="../msba-capstone/index.html">View Financial Risk Insight Engine</a>
+        </article>
 
-        <section class="card reveal" data-reveal>
-          <div class="card-image-placeholder">
-            
+        <article class="card reveal apm-project-card" data-reveal>
+          <div class="apm-project-content">
+            <h2>AI Connect 4</h2>
+            <p class="text-small">Personal Build · Consumer Gameplay Experience</p>
+            <p>
+              An interactive game experience centered on fast feedback and accessible AI behavior. I built and shipped the product to balance technical depth with usability, focusing on clear game state communication, responsive moves, and an engaging challenge loop.
+            </p>
+            <div class="tag-list">
+              <span class="tag">Interactive Product</span>
+              <span class="tag">Real-Time UX</span>
+              <span class="tag">Applied ML</span>
+            </div>
           </div>
-          <h2>AI-Powered Connect 4</h2>
-          <p class="text-small">Personal Project · Consumer AI</p>
-          <p>
-            An end-to-end interactive system using Deep Learning (CNNs) and MCTS algorithms. 
-            I prioritized a low-latency user experience by optimizing model inference, proving that 
-            complex AI can be shipped in a responsive, consumer-ready format.
-          </p>
-          <div class="tag-list">
-            <span class="tag">Deep Learning</span>
-            <span class="tag">Full-Stack</span>
-            <span class="tag">Cloud Deployment</span>
-          </div>
-          <a class="button button-primary" href="connect4/index.html">Play the AI</a>
-        </section>
-      </div>
-
-      <section class="card reveal" data-reveal style="margin-top: var(--space-6);">
-        <h2>Why I Build</h2>
-        <p>
-          Square’s mission of economic empowerment resonates with my belief that technology should 
-          be invisible yet empowering. Whether it’s helping a merchant identify tax risks or 
-          enabling a college student to personalize their financial identity, I build products 
-          that turn complex backend logic into simple, delightful frontend experiences.
-        </p>
+          <a class="button button-primary" href="../connect4/index.html">View AI Connect 4</a>
+        </article>
       </section>
+
+      <div class="apm-bottom-actions" data-reveal>
+        <a class="button button-secondary" href="../msba-capstone/index.html">Go to Financial Risk Insight Engine</a>
+        <a class="button button-secondary" href="../connect4/index.html">Go to Connect 4</a>
+      </div>
     </div>
   </main>
 


### PR DESCRIPTION
### Motivation
- Project card CTA buttons were overlapping project copy on some viewports because textual content and CTAs shared the same flex flow and relied on `margin-top: auto` behavior. This needed a predictable structure so buttons consistently sit below text without colliding.  
- Maintain the hub’s equal-height card behavior and mobile prioritization while aligning with site styling patterns and reveal behavior.

### Description
- Updated `square-apm-portfolio/index.html` to wrap all card text, tags, and descriptions in a new `.apm-project-content` container and moved the CTA `<a class="button...">` outside that wrapper so CTAs are a distinct element below the content.  
- Added layout rules to `css/styles.css`: introduced `.apm-project-content` with `flex: 1` and `gap`, normalized margins for headings/paragraphs/tag lists inside it, and replaced the previous `margin-top: auto` button behavior with an explicit `margin-top: var(--space-5)` to guarantee separation.  
- Kept existing grid, equal-height card behavior, and mobile single-column/prioritization (`.apm-hub-grid`, `.apm-project-card`, `.apm-priority`) intact so original layout intent is preserved.

### Testing
- Parsed `square-apm-portfolio/index.html` with Python `html.parser`, which completed successfully.  
- Served the site locally with `python3 -m http.server 4173` and verified `GET /css/styles.css` and `GET /js/main.js` returned `200`.  
- Captured a Playwright screenshot (`square-apm-no-overlap.png`) of `http://127.0.0.1:4173/square-apm-portfolio/index.html` which confirmed CTA buttons no longer overlap card text.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ec8e7ca883309e0ce8697e0742c6)