### PR TITLE
Redesign Connect4 quick links as retractable right sidebar

### DIFF
--- a/connect4/assets/connect4.css
+++ b/connect4/assets/connect4.css
@@ -11,20 +11,57 @@
 }
 
 .connect4-nav {
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
+  position: fixed;
+  right: var(--space-4);
+  top: max(96px, 14vh);
+  z-index: 40;
+  width: clamp(220px, 22vw, 300px);
+  transition: transform 0.28s ease;
+}
+
+.connect4-nav.is-collapsed {
+  transform: translateX(calc(100% - 44px));
+}
+
+.connect4-nav-panel {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface) 94%, var(--bg));
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.12);
+  padding: var(--space-3);
+  max-height: min(72vh, 680px);
+  overflow-y: auto;
+}
+
+.connect4-nav-title {
+  margin: 0 0 var(--space-2);
+  font-size: 0.92rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.connect4-nav-toggle {
+  width: 100%;
+  margin-bottom: var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent) 9%, var(--surface));
+  color: var(--text);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 8px 12px;
 }
 
 .connect4-nav-links {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
   gap: var(--space-2);
-  padding: var(--space-3) 0;
 }
 
 .connect4-nav-links .button {
-  font-size: 0.9rem;
-  padding: 10px 18px;
+  width: 100%;
+  font-size: 0.86rem;
+  padding: 10px 12px;
+  text-align: left;
 }
 
 .connect4-hero-placeholder {
@@ -147,9 +184,19 @@
 }
 
 @media (max-width: 720px) {
-  .connect4-nav-links {
-    flex-direction: column;
-    align-items: stretch;
+  .connect4-nav {
+    right: var(--space-2);
+    top: auto;
+    bottom: var(--space-3);
+    width: min(82vw, 300px);
+  }
+
+  .connect4-nav.is-collapsed {
+    transform: translateX(calc(100% - 38px));
+  }
+
+  .connect4-nav-panel {
+    max-height: 58vh;
   }
 
   .connect4-actions {

--- a/connect4/index.html
+++ b/connect4/index.html
@@ -17,14 +17,20 @@
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
 
-  <nav class="connect4-nav" aria-label="Connect 4 quick links">
-    <div class="container connect4-nav-links">
-      <a class="button button-secondary" href="/">Back to the Main Portfolio Website</a>
-      <a class="button button-secondary" href="/connect4/">Back to the Game's Homepage</a>
-      <a class="button button-secondary" href="/connect4/training-methodology/">How the Game Works</a>
-      <a class="button button-secondary" href="/connect4/play-transformer/">Play the Game in Casual Mode</a>
-      <a class="button button-secondary" href="/connect4/play-cnn/">Play the Game in Challenge Mode</a>
-      <a class="button button-secondary" href="/connect4/play-policy-gradient/">Play the Game in Insane Mode</a>
+  <nav class="connect4-nav" aria-label="Connect 4 quick links" data-connect4-sidebar>
+    <button class="connect4-nav-toggle" type="button" data-connect4-nav-toggle aria-expanded="true" aria-controls="connect4-nav-links">
+      Hide quick links
+    </button>
+    <div class="connect4-nav-panel">
+      <p class="connect4-nav-title">Connect 4 quick links</p>
+      <div class="connect4-nav-links" id="connect4-nav-links">
+        <a class="button button-secondary" href="/">Back to the Main Portfolio Website</a>
+        <a class="button button-secondary" href="/connect4/">Back to the Game's Homepage</a>
+        <a class="button button-secondary" href="/connect4/training-methodology/">How the Game Works</a>
+        <a class="button button-secondary" href="/connect4/play-transformer/">Play the Game in Casual Mode</a>
+        <a class="button button-secondary" href="/connect4/play-cnn/">Play the Game in Challenge Mode</a>
+        <a class="button button-secondary" href="/connect4/play-policy-gradient/">Play the Game in Insane Mode</a>
+      </div>
     </div>
   </nav>
 

--- a/connect4/play-cnn/index.html
+++ b/connect4/play-cnn/index.html
@@ -18,14 +18,20 @@
 <body data-opponent="cnn">
   <a class="skip-link" href="#main">Skip to content</a>
 
-  <nav class="connect4-nav" aria-label="Connect 4 quick links">
-    <div class="container connect4-nav-links">
-      <a class="button button-secondary" href="/">Back to the Main Portfolio Website</a>
-      <a class="button button-secondary" href="/connect4/">Back to the Game's Homepage</a>
-      <a class="button button-secondary" href="/connect4/training-methodology/">How the Game Works</a>
-      <a class="button button-secondary" href="/connect4/play-transformer/">Play the Game in Casual Mode</a>
-      <a class="button button-secondary" href="/connect4/play-cnn/">Play the Game in Challenge Mode</a>
-      <a class="button button-secondary" href="/connect4/play-policy-gradient/">Play the Game in Insane Mode</a>
+  <nav class="connect4-nav" aria-label="Connect 4 quick links" data-connect4-sidebar>
+    <button class="connect4-nav-toggle" type="button" data-connect4-nav-toggle aria-expanded="true" aria-controls="connect4-nav-links">
+      Hide quick links
+    </button>
+    <div class="connect4-nav-panel">
+      <p class="connect4-nav-title">Connect 4 quick links</p>
+      <div class="connect4-nav-links" id="connect4-nav-links">
+        <a class="button button-secondary" href="/">Back to the Main Portfolio Website</a>
+        <a class="button button-secondary" href="/connect4/">Back to the Game's Homepage</a>
+        <a class="button button-secondary" href="/connect4/training-methodology/">How the Game Works</a>
+        <a class="button button-secondary" href="/connect4/play-transformer/">Play the Game in Casual Mode</a>
+        <a class="button button-secondary" href="/connect4/play-cnn/">Play the Game in Challenge Mode</a>
+        <a class="button button-secondary" href="/connect4/play-policy-gradient/">Play the Game in Insane Mode</a>
+      </div>
     </div>
   </nav>
 

--- a/connect4/play-policy-gradient/index.html
+++ b/connect4/play-policy-gradient/index.html
@@ -24,14 +24,20 @@
     </div>
   </div> -->
 
-  <nav class="connect4-nav" aria-label="Connect 4 quick links">
-    <div class="container connect4-nav-links">
-      <a class="button button-secondary" href="/">Back to the Main Portfolio Website</a>
-      <a class="button button-secondary" href="/connect4/">Back to the Game's Homepage</a>
-      <a class="button button-secondary" href="/connect4/training-methodology/">How the Game Works</a>
-      <a class="button button-secondary" href="/connect4/play-transformer/">Play the Game in Casual Mode</a>
-      <a class="button button-secondary" href="/connect4/play-cnn/">Play the Game in Challenge Mode</a>
-      <a class="button button-secondary" href="/connect4/play-policy-gradient/">Play the Game in Insane Mode</a>
+  <nav class="connect4-nav" aria-label="Connect 4 quick links" data-connect4-sidebar>
+    <button class="connect4-nav-toggle" type="button" data-connect4-nav-toggle aria-expanded="true" aria-controls="connect4-nav-links">
+      Hide quick links
+    </button>
+    <div class="connect4-nav-panel">
+      <p class="connect4-nav-title">Connect 4 quick links</p>
+      <div class="connect4-nav-links" id="connect4-nav-links">
+        <a class="button button-secondary" href="/">Back to the Main Portfolio Website</a>
+        <a class="button button-secondary" href="/connect4/">Back to the Game's Homepage</a>
+        <a class="button button-secondary" href="/connect4/training-methodology/">How the Game Works</a>
+        <a class="button button-secondary" href="/connect4/play-transformer/">Play the Game in Casual Mode</a>
+        <a class="button button-secondary" href="/connect4/play-cnn/">Play the Game in Challenge Mode</a>
+        <a class="button button-secondary" href="/connect4/play-policy-gradient/">Play the Game in Insane Mode</a>
+      </div>
     </div>
   </nav>
 

--- a/connect4/play-transformer/index.html
+++ b/connect4/play-transformer/index.html
@@ -18,14 +18,20 @@
 <body data-opponent="transformer">
   <a class="skip-link" href="#main">Skip to content</a>
 
-  <nav class="connect4-nav" aria-label="Connect 4 quick links">
-    <div class="container connect4-nav-links">
-      <a class="button button-secondary" href="/">Back to the Main Portfolio Website</a>
-      <a class="button button-secondary" href="/connect4/">Back to the Game's Homepage</a>
-      <a class="button button-secondary" href="/connect4/training-methodology/">How the Game Works</a>
-      <a class="button button-secondary" href="/connect4/play-transformer/">Play the Game in Casual Mode</a>
-      <a class="button button-secondary" href="/connect4/play-cnn/">Play the Game in Challenge Mode</a>
-      <a class="button button-secondary" href="/connect4/play-policy-gradient/">Play the Game in Insane Mode</a>
+  <nav class="connect4-nav" aria-label="Connect 4 quick links" data-connect4-sidebar>
+    <button class="connect4-nav-toggle" type="button" data-connect4-nav-toggle aria-expanded="true" aria-controls="connect4-nav-links">
+      Hide quick links
+    </button>
+    <div class="connect4-nav-panel">
+      <p class="connect4-nav-title">Connect 4 quick links</p>
+      <div class="connect4-nav-links" id="connect4-nav-links">
+        <a class="button button-secondary" href="/">Back to the Main Portfolio Website</a>
+        <a class="button button-secondary" href="/connect4/">Back to the Game's Homepage</a>
+        <a class="button button-secondary" href="/connect4/training-methodology/">How the Game Works</a>
+        <a class="button button-secondary" href="/connect4/play-transformer/">Play the Game in Casual Mode</a>
+        <a class="button button-secondary" href="/connect4/play-cnn/">Play the Game in Challenge Mode</a>
+        <a class="button button-secondary" href="/connect4/play-policy-gradient/">Play the Game in Insane Mode</a>
+      </div>
     </div>
   </nav>
 

--- a/connect4/training-methodology/index.html
+++ b/connect4/training-methodology/index.html
@@ -17,14 +17,20 @@
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
 
-  <nav class="connect4-nav" aria-label="Connect 4 quick links">
-    <div class="container connect4-nav-links">
-      <a class="button button-secondary" href="/">Back to the Main Portfolio Website</a>
-      <a class="button button-secondary" href="/connect4/">Back to the Game's Homepage</a>
-      <a class="button button-secondary" href="/connect4/training-methodology/">How the Game Works</a>
-      <a class="button button-secondary" href="/connect4/play-transformer/">Play the Game in Casual Mode</a>
-      <a class="button button-secondary" href="/connect4/play-cnn/">Play the Game in Challenge Mode</a>
-      <a class="button button-secondary" href="/connect4/play-policy-gradient/">Play the Game in Insane Mode</a>
+  <nav class="connect4-nav" aria-label="Connect 4 quick links" data-connect4-sidebar>
+    <button class="connect4-nav-toggle" type="button" data-connect4-nav-toggle aria-expanded="true" aria-controls="connect4-nav-links">
+      Hide quick links
+    </button>
+    <div class="connect4-nav-panel">
+      <p class="connect4-nav-title">Connect 4 quick links</p>
+      <div class="connect4-nav-links" id="connect4-nav-links">
+        <a class="button button-secondary" href="/">Back to the Main Portfolio Website</a>
+        <a class="button button-secondary" href="/connect4/">Back to the Game's Homepage</a>
+        <a class="button button-secondary" href="/connect4/training-methodology/">How the Game Works</a>
+        <a class="button button-secondary" href="/connect4/play-transformer/">Play the Game in Casual Mode</a>
+        <a class="button button-secondary" href="/connect4/play-cnn/">Play the Game in Challenge Mode</a>
+        <a class="button button-secondary" href="/connect4/play-policy-gradient/">Play the Game in Insane Mode</a>
+      </div>
     </div>
   </nav>
 

--- a/js/main.js
+++ b/js/main.js
@@ -45,3 +45,14 @@ if (!prefersReducedMotion) {
     observer.observe(element);
   });
 }
+
+const connect4Sidebar = document.querySelector('[data-connect4-sidebar]');
+const connect4SidebarToggle = document.querySelector('[data-connect4-nav-toggle]');
+
+if (connect4Sidebar && connect4SidebarToggle) {
+  connect4SidebarToggle.addEventListener('click', () => {
+    const isCollapsed = connect4Sidebar.classList.toggle('is-collapsed');
+    connect4SidebarToggle.setAttribute('aria-expanded', String(!isCollapsed));
+    connect4SidebarToggle.textContent = isCollapsed ? 'Show quick links' : 'Hide quick links';
+  });
+}


### PR DESCRIPTION
### Motivation
- Move the horizontal quick-links for the Connect 4 section into a persistent, right-side navigation that is more prominent on large screens but unobtrusive and responsive on mobile. 
- Provide an affordance to hide/reveal the navigation so users can retract it while keeping it open by default.

### Description
- Replaced the top horizontal nav markup on all `/connect4/*` pages with a shared sidebar structure including a toggle button and a `data-connect4-sidebar` marker in `connect4/index.html`, `connect4/training-methodology/index.html`, `connect4/play-transformer/index.html`, `connect4/play-cnn/index.html`, and `connect4/play-policy-gradient/index.html`.
- Added sidebar styles in `connect4/assets/connect4.css` to implement a fixed right-side panel, responsive sizing (`clamp` / `vw`), mobile bottom placement, an `.is-collapsed` transform for retraction, and improved panel visuals (`.connect4-nav-panel`, `.connect4-nav-toggle`, `.connect4-nav-links`).
- Wired interaction in `js/main.js` to toggle the `.is-collapsed` class, update `aria-expanded`, and flip the toggle label between `Hide quick links` and `Show quick links` so the sidebar is open by default and accessible.

### Testing
- Ran a verification script (`python - <<'PY'`) that asserts `data-connect4-sidebar` and `data-connect4-nav-toggle` are present in all five `/connect4/*` pages; the check passed.
- Launched a local static server (`python -m http.server`) and used a Playwright script to capture desktop and mobile screenshots of `http://127.0.0.1:4173/connect4/` for visual verification; screenshots were produced successfully.
- Static server responses and local checks (HTTP 200 for assets and pages) completed successfully during automated validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b43f449e883309c1b0db30dd91947)