### PR TITLE
Make Connect4 sidebar collapse like an accordion and update toggle labels

### DIFF
--- a/connect4/assets/connect4.css
+++ b/connect4/assets/connect4.css
@@ -16,11 +16,11 @@
   top: max(96px, 14vh);
   z-index: 40;
   width: clamp(220px, 22vw, 300px);
-  transition: transform 0.28s ease;
 }
 
-.connect4-nav.is-collapsed {
-  transform: translateX(calc(100% - 44px));
+
+.connect4-nav.is-collapsed .connect4-nav-panel {
+  display: none;
 }
 
 .connect4-nav-panel {
@@ -191,9 +191,6 @@
     width: min(82vw, 300px);
   }
 
-  .connect4-nav.is-collapsed {
-    transform: translateX(calc(100% - 38px));
-  }
 
   .connect4-nav-panel {
     max-height: 58vh;

--- a/connect4/index.html
+++ b/connect4/index.html
@@ -19,7 +19,7 @@
 
   <nav class="connect4-nav" aria-label="Connect 4 quick links" data-connect4-sidebar>
     <button class="connect4-nav-toggle" type="button" data-connect4-nav-toggle aria-expanded="true" aria-controls="connect4-nav-links">
-      Hide quick links
+      Hide Connect 4 Quick Links
     </button>
     <div class="connect4-nav-panel">
       <p class="connect4-nav-title">Connect 4 quick links</p>

--- a/connect4/play-cnn/index.html
+++ b/connect4/play-cnn/index.html
@@ -20,7 +20,7 @@
 
   <nav class="connect4-nav" aria-label="Connect 4 quick links" data-connect4-sidebar>
     <button class="connect4-nav-toggle" type="button" data-connect4-nav-toggle aria-expanded="true" aria-controls="connect4-nav-links">
-      Hide quick links
+      Hide Connect 4 Quick Links
     </button>
     <div class="connect4-nav-panel">
       <p class="connect4-nav-title">Connect 4 quick links</p>

--- a/connect4/play-policy-gradient/index.html
+++ b/connect4/play-policy-gradient/index.html
@@ -26,7 +26,7 @@
 
   <nav class="connect4-nav" aria-label="Connect 4 quick links" data-connect4-sidebar>
     <button class="connect4-nav-toggle" type="button" data-connect4-nav-toggle aria-expanded="true" aria-controls="connect4-nav-links">
-      Hide quick links
+      Hide Connect 4 Quick Links
     </button>
     <div class="connect4-nav-panel">
       <p class="connect4-nav-title">Connect 4 quick links</p>

--- a/connect4/play-transformer/index.html
+++ b/connect4/play-transformer/index.html
@@ -20,7 +20,7 @@
 
   <nav class="connect4-nav" aria-label="Connect 4 quick links" data-connect4-sidebar>
     <button class="connect4-nav-toggle" type="button" data-connect4-nav-toggle aria-expanded="true" aria-controls="connect4-nav-links">
-      Hide quick links
+      Hide Connect 4 Quick Links
     </button>
     <div class="connect4-nav-panel">
       <p class="connect4-nav-title">Connect 4 quick links</p>

--- a/connect4/training-methodology/index.html
+++ b/connect4/training-methodology/index.html
@@ -19,7 +19,7 @@
 
   <nav class="connect4-nav" aria-label="Connect 4 quick links" data-connect4-sidebar>
     <button class="connect4-nav-toggle" type="button" data-connect4-nav-toggle aria-expanded="true" aria-controls="connect4-nav-links">
-      Hide quick links
+      Hide Connect 4 Quick Links
     </button>
     <div class="connect4-nav-panel">
       <p class="connect4-nav-title">Connect 4 quick links</p>

--- a/js/main.js
+++ b/js/main.js
@@ -53,6 +53,8 @@ if (connect4Sidebar && connect4SidebarToggle) {
   connect4SidebarToggle.addEventListener('click', () => {
     const isCollapsed = connect4Sidebar.classList.toggle('is-collapsed');
     connect4SidebarToggle.setAttribute('aria-expanded', String(!isCollapsed));
-    connect4SidebarToggle.textContent = isCollapsed ? 'Show quick links' : 'Hide quick links';
+    connect4SidebarToggle.textContent = isCollapsed
+      ? 'Show Connect 4 Quick Links'
+      : 'Hide Connect 4 Quick Links';
   });
 }


### PR DESCRIPTION
### Motivation
- Change the Connect 4 quick-links sidebar to collapse in place (accordion behavior) instead of translating the whole sidebar off the page for a more compact UX.
- Standardize the toggle wording to make the action explicit by using `Hide Connect 4 Quick Links` when expanded and `Show Connect 4 Quick Links` when collapsed.

### Description
- CSS: stop translating the nav and hide the inner panel when collapsed by updating `connect4/assets/connect4.css` to remove the `transform` collapse and add `.connect4-nav.is-collapsed .connect4-nav-panel { display: none; }`.
- JS: update toggle label logic in `js/main.js` to set the exact strings `Show Connect 4 Quick Links` and `Hide Connect 4 Quick Links` when toggling collapse state.
- HTML: update the default toggle text on all `/connect4/*` pages so the visible label is `Hide Connect 4 Quick Links` by default (`connect4/index.html`, `connect4/play-cnn/index.html`, `connect4/play-transformer/index.html`, `connect4/play-policy-gradient/index.html`, `connect4/training-methodology/index.html`).

### Testing
- Verified labels and code changes with a search (`rg -n "Hide Connect 4 Quick Links|Show Connect 4 Quick Links" connect4 js/main.js`) which returned the updated files; this check passed.
- Served the site locally with `python3 -m http.server 4173` and exercised the toggle via a Playwright script that clicked the `[data-connect4-nav-toggle]` button and captured a screenshot; the script ran successfully and produced a collapsed-state screenshot artifact (`artifacts/connect4-sidebar-collapsed.png`).
- Ran a final filesystem diff to confirm the expected files were updated; the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b472ae27883308f83d8b6018f3b55)