### PR TITLE
Make Connect 4 sidebar collapse inline (accordion) with smooth transition

### DIFF
--- a/connect4/assets/connect4.css
+++ b/connect4/assets/connect4.css
@@ -16,21 +16,26 @@
   top: max(96px, 14vh);
   z-index: 40;
   width: clamp(220px, 22vw, 300px);
-}
-
-
-.connect4-nav.is-collapsed .connect4-nav-panel {
-  display: none;
-}
-
-.connect4-nav-panel {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--surface) 94%, var(--bg));
   box-shadow: 0 16px 28px rgba(15, 23, 42, 0.12);
   padding: var(--space-3);
+}
+
+
+.connect4-nav-panel {
+  padding-top: var(--space-2);
   max-height: min(72vh, 680px);
   overflow-y: auto;
+  transition: max-height 0.25s ease, opacity 0.2s ease, padding 0.2s ease;
+}
+
+.connect4-nav.is-collapsed .connect4-nav-panel {
+  max-height: 0;
+  opacity: 0;
+  padding-top: 0;
+  overflow: hidden;
 }
 
 .connect4-nav-title {
@@ -42,7 +47,6 @@
 
 .connect4-nav-toggle {
   width: 100%;
-  margin-bottom: var(--space-2);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--accent) 9%, var(--surface));


### PR DESCRIPTION
### Motivation
- The quick-links panel should collapse into the main sidebar card (accordion-style) instead of disappearing off to the side to provide a cleaner, single-card UI on all `/connect4/*` pages. 
- Collapse/expand text needs to remain consistent and repeatable across pages using the centralized toggle behavior.

### Description
- Moved the visual card chrome (border/background/shadow/padding) from `.connect4-nav-panel` to the container `.connect4-nav` so the toggle stays on a single card. 
- Replaced the previous hide behavior with an in-place accordion that animates the inner panel using `max-height`, `opacity`, and `padding-top` and added a `transition` for smooth collapsing in `connect4/assets/connect4.css`. 
- Left the centralized toggle copy in `js/main.js` intact so collapsed state shows `Show Connect 4 Quick Links` and expanded state shows `Hide Connect 4 Quick Links` consistently across all `/connect4/*` pages.

### Testing
- Ran a text consistency check with `rg -n "Hide Connect 4 Quick Links|Show Connect 4 Quick Links"` to verify the toggle copy is present and centralized in `js/main.js` (succeeded). 
- Served the site with `python3 -m http.server 8000` and fetched the `/connect4/` page with `curl` to validate the updated markup and that the page loads (succeeded). 
- Attempted a Playwright screenshot to validate the visual collapsed state, but the automated browser run timed out / returned `Not Found` in this environment (failed to produce a reliable screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b4ec4cca0833086d84261ddcc39cb)